### PR TITLE
위시리스트 기능 구현

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -21,6 +21,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'mysql:mysql-connector-java:8.0.23'
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 tasks.named('test') {

--- a/common/src/main/java/com/doosan/common/utils/JwtUtil.java
+++ b/common/src/main/java/com/doosan/common/utils/JwtUtil.java
@@ -1,0 +1,55 @@
+package com.doosan.common.utils;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Base64;
+import java.util.Date;
+
+@Slf4j(topic = "JwtUtil")
+@Component
+public class JwtUtil {
+    public static final String BEARER_PREFIX = "Bearer ";
+    private final long ACCESS_TOKEN_TIME = 30 * 60 * 1000L; // 30분
+    private final long REFRESH_TOKEN_TIME = 7 * 24 * 60 * 60 * 1000L; // 7일
+
+    @Value("${jwt.secret.key}")
+    private String secretKey;
+    private Key key;
+    private final SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.HS256;
+
+    @PostConstruct
+    public void init() {
+        byte[] bytes = Base64.getDecoder().decode(secretKey);
+        key = Keys.hmacShaKeyFor(bytes);
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    public int getUserIdFromToken(String token) {
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+        
+        return Integer.parseInt(claims.get("userId").toString());
+    }
+} 

--- a/common/src/main/java/com/doosan/common/utils/ParseRequestUtil.java
+++ b/common/src/main/java/com/doosan/common/utils/ParseRequestUtil.java
@@ -3,20 +3,19 @@ package com.doosan.common.utils;
 import jakarta.servlet.http.HttpServletRequest;
 
 public class ParseRequestUtil {
+    private final JwtUtil jwtUtil;
+
+    public ParseRequestUtil(JwtUtil jwtUtil) {
+        this.jwtUtil = jwtUtil;
+    }
 
     public int extractUserIdFromRequest(HttpServletRequest request) {
-        String userIdHeader = request.getHeader("x-claim-userid");
-        if (userIdHeader == null) {
-            throw new RuntimeException("헤더에 사용자 ID가 없습니다.");
+        String authHeader = request.getHeader("Authorization");
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            throw new RuntimeException("인증 토큰이 없거나 잘못된 형식입니다.");
         }
 
-        int userId;
-        try {
-            userId = Integer.parseInt(userIdHeader);
-        } catch (NumberFormatException e) {
-            throw new RuntimeException("헤더에 있는 사용자 ID 형식이 잘못되었습니다.");
-        }
-
-        return userId;
+        String token = authHeader.substring(7);
+        return jwtUtil.getUserIdFromToken(token);
     }
 }

--- a/order-service/src/main/java/com/doosan/orderservice/config/JwtConfig.java
+++ b/order-service/src/main/java/com/doosan/orderservice/config/JwtConfig.java
@@ -1,0 +1,14 @@
+package com.doosan.orderservice.config;
+
+import com.doosan.common.utils.JwtUtil;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JwtConfig {
+    
+    @Bean
+    public JwtUtil jwtUtil() {
+        return new JwtUtil();
+    }
+} 

--- a/order-service/src/main/java/com/doosan/orderservice/controller/OrderController.java
+++ b/order-service/src/main/java/com/doosan/orderservice/controller/OrderController.java
@@ -1,15 +1,17 @@
 package com.doosan.orderservice.controller;
 
-
 import com.doosan.common.dto.ResponseDto;
 import com.doosan.common.dto.ResponseMessage;
 import com.doosan.common.dto.order.CreateOrderReqDto;
+import com.doosan.common.utils.JwtUtil;
 import com.doosan.common.utils.ParseRequestUtil;
 import com.doosan.orderservice.dto.CreateOrderResDto;
 import com.doosan.orderservice.dto.OrderStatusUpdateRequest;
+import com.doosan.orderservice.dto.WishListDto;
+import com.doosan.orderservice.dto.WishListOrderResponseDto;
 import com.doosan.orderservice.service.OrderService;
 import jakarta.servlet.http.HttpServletRequest;
-import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -17,17 +19,23 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/order")
-@RequiredArgsConstructor
 public class OrderController {
 
     private final OrderService orderService;
+    private final ParseRequestUtil parseRequestUtil;
+
+    @Autowired
+    public OrderController(OrderService orderService, JwtUtil jwtUtil) {
+        this.orderService = orderService;
+        this.parseRequestUtil = new ParseRequestUtil(jwtUtil);
+    }
 
     // 주문 취소
     @PostMapping("/{orderId}/cancel")
     public ResponseEntity<ResponseDto<Void>> cancelOrder(
             HttpServletRequest request,
             @PathVariable int orderId) {
-        int userId = new ParseRequestUtil().extractUserIdFromRequest(request);
+        int userId = parseRequestUtil.extractUserIdFromRequest(request);
         return orderService.cancelOrder(userId, orderId);
     }
 
@@ -36,14 +44,14 @@ public class OrderController {
     public ResponseEntity<ResponseDto<Void>> requestReturn(
             HttpServletRequest request,
             @PathVariable int orderId) {
-        int userId = new ParseRequestUtil().extractUserIdFromRequest(request);
+        int userId = parseRequestUtil.extractUserIdFromRequest(request);
         return orderService.requestReturn(userId, orderId);
     }
 
     // 주문 생성
     @PostMapping("create-order")
     public ResponseEntity<ResponseMessage> createOrder(HttpServletRequest request, @RequestBody List<CreateOrderReqDto> orderItems) {
-        int userId = new ParseRequestUtil().extractUserIdFromRequest(request);
+        int userId = parseRequestUtil.extractUserIdFromRequest(request);
 
         CreateOrderResDto orderResponse = orderService.createOrder(userId, orderItems);
 
@@ -60,6 +68,51 @@ public class OrderController {
     @PutMapping("/status")
     public ResponseEntity<?> updateOrderStatus(@RequestBody OrderStatusUpdateRequest request) {
         return orderService.updateOrderStatus(request);
+    }
+
+    // WishList 조회
+    @GetMapping("/wishlist")
+    public ResponseEntity<ResponseDto<List<WishListDto>>> getWishList(HttpServletRequest request) {
+        int userId = parseRequestUtil.extractUserIdFromRequest(request);
+        return orderService.getWishList(userId);
+    }
+
+    // WishList에 상품 추가
+    @PostMapping("/wishlist/{productId}")
+    public ResponseEntity<ResponseDto<Void>> addToWishList(
+            HttpServletRequest request,
+            @PathVariable Long productId,
+            @RequestParam(defaultValue = "1") int quantity) {
+        int userId = parseRequestUtil.extractUserIdFromRequest(request);
+        return orderService.addToWishList(userId, productId, quantity);
+    }
+
+    // WishList 상품 수량 수정
+    @PutMapping("/wishlist/{productId}")
+    public ResponseEntity<ResponseDto<Void>> updateWishListItem(
+            HttpServletRequest request,
+            @PathVariable Long productId,
+            @RequestParam int quantity) {
+        int userId = parseRequestUtil.extractUserIdFromRequest(request);
+        return orderService.updateWishListItem(userId, productId, quantity);
+    }
+
+    // WishList에서 상품 제거
+    @DeleteMapping("/wishlist/{productId}")
+    public ResponseEntity<ResponseDto<Void>> removeFromWishList(
+            HttpServletRequest request,
+            @PathVariable Long productId) {
+        int userId = parseRequestUtil.extractUserIdFromRequest(request);
+        return orderService.removeFromWishList(userId, productId);
+    }
+
+    // WishList 상품들 주문
+    @PostMapping("/wishlist/order")
+    public ResponseEntity<ResponseDto<WishListOrderResponseDto>> orderFromWishList(
+            HttpServletRequest request,
+            @RequestBody List<Long> productIds) {
+        int userId = parseRequestUtil.extractUserIdFromRequest(request);
+        return orderService.orderFromWishList(userId, productIds);
     }
 
 }

--- a/order-service/src/main/java/com/doosan/orderservice/dto/OrderItemDto.java
+++ b/order-service/src/main/java/com/doosan/orderservice/dto/OrderItemDto.java
@@ -1,0 +1,15 @@
+package com.doosan.orderservice.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class OrderItemDto {
+    private Long productId; // 상품아이디
+    private String productName; //상품이름
+    private int quantity;//수량
+    private long price;//가격
+} 

--- a/order-service/src/main/java/com/doosan/orderservice/dto/WishListDto.java
+++ b/order-service/src/main/java/com/doosan/orderservice/dto/WishListDto.java
@@ -1,0 +1,14 @@
+package com.doosan.orderservice.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class WishListDto {
+    private Long productId; // 상품 아이디
+    private Integer quantity; // 수량
+    private String productName; // 상품이름
+    private Long price; // 가격
+    private String description; // 상품설명
+} 

--- a/order-service/src/main/java/com/doosan/orderservice/dto/WishListOrderResponseDto.java
+++ b/order-service/src/main/java/com/doosan/orderservice/dto/WishListOrderResponseDto.java
@@ -1,0 +1,18 @@
+package com.doosan.orderservice.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import java.util.Date;
+import java.util.List;
+
+@Getter
+@Setter
+@Builder
+public class WishListOrderResponseDto {
+    private int orderId; // 주문 아이디
+    private int userId; // 유저 아이디
+    private Date orderDate; // 주문 날짜
+    private long totalPrice; // 총가격
+    private List<OrderItemDto> items; // 담긴 상품들
+} 

--- a/order-service/src/main/java/com/doosan/orderservice/entity/WishList.java
+++ b/order-service/src/main/java/com/doosan/orderservice/entity/WishList.java
@@ -1,0 +1,20 @@
+package com.doosan.orderservice.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@Table(name = "wish_list")
+public class WishList {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id; // 위시리스트 아이디
+    
+    private Integer userId; // 유저 아이디
+    private Long productId; // 상품 아이디
+    private Integer quantity; // 수량
+    private boolean isDeleted; // 삭제여부
+} 

--- a/order-service/src/main/java/com/doosan/orderservice/repository/WishListRepository.java
+++ b/order-service/src/main/java/com/doosan/orderservice/repository/WishListRepository.java
@@ -1,0 +1,13 @@
+package com.doosan.orderservice.repository;
+
+import com.doosan.orderservice.entity.WishList;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface WishListRepository extends JpaRepository<WishList, Integer> {
+    List<WishList> findByUserIdAndIsDeletedFalse(Integer userId);
+    boolean existsByUserIdAndProductIdAndIsDeletedFalse(Integer userId, Long productId);
+    Optional<WishList> findByUserIdAndProductIdAndIsDeletedFalse(int userId, Long productId);
+} 

--- a/order-service/src/main/java/com/doosan/orderservice/service/OrderService.java
+++ b/order-service/src/main/java/com/doosan/orderservice/service/OrderService.java
@@ -4,6 +4,8 @@ import com.doosan.common.dto.ResponseDto;
 import com.doosan.common.dto.order.CreateOrderReqDto;
 import com.doosan.orderservice.dto.CreateOrderResDto;
 import com.doosan.orderservice.dto.OrderStatusUpdateRequest;
+import com.doosan.orderservice.dto.WishListDto;
+import com.doosan.orderservice.dto.WishListOrderResponseDto;
 import org.springframework.http.ResponseEntity;
 
 import java.util.List;
@@ -14,4 +16,9 @@ public interface OrderService {
     ResponseEntity<ResponseDto<Void>> requestReturn(int userId, int orderId);
     ResponseEntity<?> updateOrderStatus(OrderStatusUpdateRequest request);
     void updateOrderStatus();
+    ResponseEntity<ResponseDto<List<WishListDto>>> getWishList(int userId);
+    ResponseEntity<ResponseDto<Void>> addToWishList(int userId, Long productId, int quantity);
+    ResponseEntity<ResponseDto<Void>> updateWishListItem(int userId, Long productId, int quantity);
+    ResponseEntity<ResponseDto<Void>> removeFromWishList(int userId, Long productId);
+    ResponseEntity<ResponseDto<WishListOrderResponseDto>> orderFromWishList(int userId, List<Long> productIds);
 }


### PR DESCRIPTION
###  위시리스트 CRUD 기능 구현
  - 위시리스트 조회 
    http://localhost:8000/order-service/api/v1/order/wishlist

  - 위시리스트 상품 추가
   http://localhost:8000/order-service/api/v1/order/wishlist/8?quantity=24

  - 위시리스트 상품 수량 수정
   http://localhost:8000/order-service/api/v1/order/wishlist/2?quantity=1

  - 위시리스트 상품 삭제
   http://localhost:8000/order-service/api/v1/order/wishlist/2

- 위시리스트 상품 주문 기능 구현
  http://localhost:8000/order-service/api/v1/order/wishlist/order

- Header에 X-USER-ID  없이 토큰만으로 사용자 구분하도록 JWT 인증 기능 추가

### 상세 변경사항:
- WishList 엔티티 및 Repository 추가
- WishListDto, WishListOrderResponseDto 추가
- OrderService에 위시리스트 관련 메서드 추가
- JWT 설정 및 유틸리티 클래스 추가